### PR TITLE
Wrapper width limit fix and some fixes from others

### DIFF
--- a/complete.ly.1.0.1.js
+++ b/complete.ly.1.0.1.js
@@ -1,5 +1,5 @@
 /**
- * complete.ly 1.0.1
+ * complete.ly 1.0.1.1
  * MIT Licensing
  * Copyright (c) 2013 Lorenzo Puccetti
  * 

--- a/complete.ly.1.0.1.js
+++ b/complete.ly.1.0.1.js
@@ -1,5 +1,5 @@
 /**
- * complete.ly 1.0.0
+ * complete.ly 1.0.1
  * MIT Licensing
  * Copyright (c) 2013 Lorenzo Puccetti
  * 
@@ -24,14 +24,14 @@ function completely(container, config) {
     txtInput.style.fontSize =        config.fontSize;
     txtInput.style.fontFamily =      config.fontFamily;
     txtInput.style.color =           config.color;
-    txtInput.style.backgroundColor = config.backgroundColor;
+    txtInput.style.backgroundColor = "url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEUAAACnej3aAAAAAXRSTlMAQObYZgAAAApJREFUCNdjYAAAAAIAAeIhvDMAAAAASUVORK5CYII=)";
     txtInput.style.width = '100%';
     txtInput.style.outline = '0';
     txtInput.style.border =  '0';
     txtInput.style.margin =  '0';
     txtInput.style.padding = '0';
     
-    var txtHint = txtInput.cloneNode(); 
+    var txtHint = txtInput.cloneNode(true); 
     txtHint.disabled='';        
     txtHint.style.position = 'absolute';
     txtHint.style.top =  '0';
@@ -212,7 +212,9 @@ function completely(container, config) {
                                        .replace(/'/g, '&#39;')
                                        .replace(/</g, '&lt;')
                                        .replace(/>/g, '&gt;');
-        return spacer.getBoundingClientRect().right;
+		if (spacer.getBoundingClientRect().right > wrapper.getBoundingClientRect().width)
+			 return wrapper.getBoundingClientRect().width; 
+		else return spacer.getBoundingClientRect().right; 
     }
     
     

--- a/complete.ly.1.0.1.js
+++ b/complete.ly.1.0.1.js
@@ -177,6 +177,7 @@ function completely(container, config) {
     dropDownController.onmouseselection = function(text) {
         txtInput.value = txtHint.value = leftSide+text; 
         rs.onChange(txtInput.value); // <-- forcing it.
+	scrollLeftEnd();
         registerOnTextChangeOldValue = txtInput.value; // <-- ensure that mouse down will not show the dropDown now.
         setTimeout(function() { txtInput.focus(); },0);  // <-- I need to do this for IE 
     }
@@ -215,6 +216,10 @@ function completely(container, config) {
 		if (spacer.getBoundingClientRect().right > wrapper.getBoundingClientRect().width)
 			 return wrapper.getBoundingClientRect().width; 
 		else return spacer.getBoundingClientRect().right; 
+    }
+	
+    function scrollLeftEnd() {
+        txtInput.scrollLeft = txtInput.getBoundingClientRect().width;
     }
     
     
@@ -341,6 +346,7 @@ function completely(container, config) {
                                                           // user has hit enter to get 'bee' it would be prompted with the dropDown again (as beef and beetroot also match)
                 if (hasTextChanged) {
                     rs.onChange(txtInput.value); // <-- forcing it.
+		    scrollLeftEnd();
                 }
             }
             return; 
@@ -367,6 +373,7 @@ function completely(container, config) {
                                                           // user has hit enter to get 'bee' it would be prompted with the dropDown again (as beef and beetroot also match)
                 if (hasTextChanged) {
                     rs.onChange(txtInput.value); // <-- forcing it.
+		    scrollLeftEnd();
                 }
                 
             }

--- a/complete.ly.1.0.1.js
+++ b/complete.ly.1.0.1.js
@@ -187,8 +187,11 @@ function completely(container, config) {
     
     var spacer; 
     var leftSide; // <-- it will contain the leftSide part of the textfield (the bit that was already autocompleted)
-    
-    
+	
+    function scrollLeftEnd() {
+        txtInput.scrollLeft = txtInput.getBoundingClientRect().width;
+    }
+	
     function calculateWidthForText(text) {
         if (spacer === undefined) { // on first call only.
             spacer = document.createElement('span'); 
@@ -218,9 +221,7 @@ function completely(container, config) {
 		else return spacer.getBoundingClientRect().right; 
     }
 	
-    function scrollLeftEnd() {
-        txtInput.scrollLeft = txtInput.getBoundingClientRect().width;
-    }
+
     
     
     var rs = { 


### PR DESCRIPTION
This request contains:

- My fixes for `calculateWidthForText()` #34 
- Modify `txtInput.scrollLeft` after `onChange()` 
- Older browser compatibility issue (Firefox 3.5.9) #17 
- Browser Mode:IE8 Document Mode: IE8 standards #15